### PR TITLE
fix: specify the version range of `kotlinforforge`

### DIFF
--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -33,7 +33,7 @@ side="BOTH"
 [[dependencies.villager_inventory_hwyla_plugin]]
 modId="kotlinforforge"
 type="optional"
-versionRange=""
+versionRange="[6.1,)"
 ordering="NONE"
 side="BOTH"
 


### PR DESCRIPTION
fix #75 