### PR TITLE
chore: change supported minecraft version range

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,6 +7,6 @@ org.gradle.configuration-cache=true
 # Mod Properties
 mod_version=2.0.0-dev
 mod_version_type=alpha
-minecraft_forward_compatible_versions=26.1.1,26.1.2
+minecraft_forward_compatible_versions=26.1.1,26.1.2,26.2-pre-4,26.2-pre-5,26.2-pre-6,26.2-rc-1
 maven_group=dev.kpherox.mcmods
 archives_base_name=villager-inventory-hwyla-plugin

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
 		]
 	},
 	"depends": {
-		"minecraft": "~${minecraft}",
+		"minecraft": ">=${minecraft}",
 		"java": ">=${java}",
 		"fabric-language-kotlin": "*"
 	},


### PR DESCRIPTION
still works on 26.2